### PR TITLE
[DOCS] Add docs (GitHub Pages)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+name: Publish documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        working-directory: docs
+        run: bundle exec jekyll build --destination ../_site
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -97,7 +97,7 @@
     <!-- About / API info -->
     <hr>
     <div class="ipquery-panel" style="margin-top:16px;">
-        <h3><?php esc_html_e( 'About IpQuery API', 'ipquery-wp' ); ?></h3>
+        <h3><?php esc_html_e( 'About IpQuery for WordPress', 'ipquery-wp' ); ?></h3>
         <p>
             <?php esc_html_e( 'This plugin uses the free IpQuery API (', 'ipquery-wp' ); ?>
             <a href="https://ipquery.io" target="_blank" rel="noopener">ipquery.io</a>
@@ -107,12 +107,19 @@
             <?php esc_html_e( 'Lookups are cached for 1 hour per IP via WordPress transients to minimise API calls and avoid rate limits.', 'ipquery-wp' ); ?>
         </p>
         <p>
-            <strong><?php esc_html_e( 'Plugin:', 'ipquery-wp' ); ?></strong>
-            <a href="https://github.com/guibranco/ipquery-wordpress" target="_blank" rel="noopener">guibranco/ipquery-wordpress</a>
+            <a href="https://guilherme.stracini.com.br/ipquery-wordpress/" target="_blank" rel="noopener" class="button button-secondary">
+                <?php esc_html_e( 'Documentation', 'ipquery-wp' ); ?>
+            </a>
+            &nbsp;
+            <a href="https://github.com/guibranco/ipquery-wordpress" target="_blank" rel="noopener" class="button button-secondary">
+                <?php esc_html_e( 'GitHub', 'ipquery-wp' ); ?>
+            </a>
         </p>
         <p>
             <strong><?php esc_html_e( 'PHP Library:', 'ipquery-wp' ); ?></strong>
             <a href="https://github.com/guibranco/ipquery-php" target="_blank" rel="noopener">guibranco/ipquery-php</a>
+            &mdash;
+            <?php esc_html_e( 'the underlying API client bundled inside this plugin.', 'ipquery-wp' ); ?>
         </p>
 
         <table class="widefat striped" style="max-width:500px;margin-top:12px;">

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,6 @@
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+vendor/
+Gemfile.lock

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "just-the-docs", "~> 0.10"
+gem "jekyll", "~> 4.3"
+
+group :jekyll_plugins do
+  gem "jekyll-seo-tag"
+  gem "jekyll-sitemap"
+end

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,60 @@
+title: IpQuery for WordPress
+description: >-
+  Track and analyse visitor IP data using the IpQuery API.
+  Displays location maps, traffic heatmaps, and VPN/proxy statistics.
+
+url: "https://guilherme.stracini.com.br"
+baseurl: "/ipquery-wordpress"
+
+theme: just-the-docs
+
+# ── Navigation ────────────────────────────────────────────────────────────────
+search_enabled: true
+heading_anchors: true
+permalink: pretty
+
+# ── Header links ─────────────────────────────────────────────────────────────
+aux_links:
+  "GitHub":
+    - "https://github.com/guibranco/ipquery-wordpress"
+  "IpQuery API":
+    - "https://ipquery.io"
+
+aux_links_new_tab: true
+
+# ── Footer ────────────────────────────────────────────────────────────────────
+footer_content: >-
+  IpQuery for WordPress is open source under the
+  <a href="https://github.com/guibranco/ipquery-wordpress/blob/main/LICENSE" target="_blank">MIT licence</a>.
+  Powered by <a href="https://github.com/guibranco/ipquery-php" target="_blank">guibranco/ipquery-php</a>
+  and the <a href="https://ipquery.io" target="_blank">IpQuery API</a>.
+
+# ── Code blocks ───────────────────────────────────────────────────────────────
+enable_copy_code_button: true
+
+# ── Callouts ──────────────────────────────────────────────────────────────────
+callouts:
+  note:
+    title: Note
+    color: blue
+  tip:
+    title: Tip
+    color: green
+  warning:
+    title: Warning
+    color: red
+  important:
+    title: Important
+    color: yellow
+
+# ── Plugins ───────────────────────────────────────────────────────────────────
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+# ── Exclude from build ────────────────────────────────────────────────────────
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - "*.gem"
+  - vendor/

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,165 @@
+---
+title: IpQuery API
+nav_order: 7
+---
+
+# IpQuery API
+
+The plugin communicates with the [IpQuery API](https://ipquery.io) via the [guibranco/ipquery-php](https://github.com/guibranco/ipquery-php) library. This page documents the API endpoints and response fields used by the plugin.
+
+---
+
+## Endpoint
+
+All requests go to:
+
+```
+https://api.ipquery.io/{ip}?format=json
+```
+
+- **No API key required** for standard usage.
+- Responses are JSON objects.
+- The library sets a `User-Agent` of `IpQuery PHP Client/1.0`.
+- Timeouts: 5 s connection, 10 s total.
+
+---
+
+## Response structure
+
+A successful response looks like this:
+
+```json
+{
+  "ip": "203.0.113.42",
+  "isp": {
+    "asn": "AS15169",
+    "org": "Google LLC",
+    "isp": "Google"
+  },
+  "location": {
+    "country": "United States",
+    "country_code": "US",
+    "city": "Mountain View",
+    "state": "California",
+    "zipcode": "94043",
+    "latitude": 37.4056,
+    "longitude": -122.0775,
+    "timezone": "America/Los_Angeles",
+    "localtime": "2026-04-22T10:30:00"
+  },
+  "risk": {
+    "is_mobile": false,
+    "is_vpn": false,
+    "is_tor": false,
+    "is_proxy": false,
+    "is_datacenter": true,
+    "risk_score": 35
+  }
+}
+```
+
+---
+
+## Field reference
+
+### `isp` object
+
+| Field | Type | Description |
+|---|---|---|
+| `asn` | string | Autonomous System Number (e.g. `AS15169`) |
+| `org` | string | Organisation name registered to the ASN |
+| `isp` | string | Internet Service Provider name |
+
+### `location` object
+
+| Field | Type | Description |
+|---|---|---|
+| `country` | string | Full country name |
+| `country_code` | string | ISO 3166-1 alpha-2 code (e.g. `US`, `BR`) |
+| `city` | string | City name |
+| `state` | string | State or region name |
+| `zipcode` | string | Postal/ZIP code |
+| `latitude` | float | Decimal latitude |
+| `longitude` | float | Decimal longitude |
+| `timezone` | string | IANA timezone identifier (e.g. `America/New_York`) |
+| `localtime` | string | Local time at the IP's location (ISO 8601) |
+
+### `risk` object
+
+| Field | Type | Description |
+|---|---|---|
+| `is_mobile` | bool | IP belongs to a mobile carrier |
+| `is_vpn` | bool | IP is a known VPN exit node |
+| `is_tor` | bool | IP is a Tor exit node |
+| `is_proxy` | bool | IP is a known open proxy |
+| `is_datacenter` | bool | IP is assigned to a datacenter or cloud provider |
+| `risk_score` | int | Composite risk score from 0 (clean) to 100 (high risk) |
+
+---
+
+## PHP library classes
+
+The library is bundled in `includes/vendor/` and uses the namespace `GuiBranco\IpQuery`.
+
+### `IpQueryClient`
+
+The main client class. No constructor arguments required.
+
+```php
+use GuiBranco\IpQuery\IpQueryClient;
+
+$client = new IpQueryClient();
+
+// Single IP
+$response = $client->getIpData('203.0.113.42');
+
+// Multiple IPs (one API call)
+$responses = $client->getMultipleIpData(['203.0.113.42', '198.51.100.1']);
+
+// Server's own IP
+$self = $client->getMyIpData();
+```
+
+### `IpQueryResponse`
+
+Returned by all three methods. Properties:
+
+```php
+$response->ip        // string
+$response->isp       // GuiBranco\IpQuery\Response\Isp
+$response->location  // GuiBranco\IpQuery\Response\Location
+$response->risk      // GuiBranco\IpQuery\Response\Risk
+```
+
+### `IpQueryException`
+
+Thrown by `IpQueryClient` on network errors or non-200 HTTP responses. Extends `\RuntimeException`.
+
+```php
+use GuiBranco\IpQuery\IpQueryException;
+
+try {
+    $response = $client->getIpData($ip);
+} catch (IpQueryException $e) {
+    error_log('[IpQuery WP] ' . $e->getMessage());
+}
+```
+
+---
+
+## Rate limiting
+
+The IpQuery API is free for standard usage. The plugin avoids excessive calls by:
+
+1. Caching each lookup in a WordPress transient for **1 hour**.
+2. Only calling the API from the `shutdown` action (after response is sent).
+3. Batch requests are available via `getMultipleIpData()` if you need to bulk-enrich IPs programmatically.
+
+For high-traffic sites, consider raising the transient TTL by filtering the value via a custom plugin or `mu-plugin`.
+
+---
+
+## Further reading
+
+- [ipquery.io](https://ipquery.io) — API documentation and usage information
+- [guibranco/ipquery-php on GitHub](https://github.com/guibranco/ipquery-php) — source code, tests, and issue tracker for the PHP client library

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,92 @@
+---
+title: Configuration
+nav_order: 3
+---
+
+# Configuration
+
+All settings are found at **IpQuery → Settings** in the WordPress admin.
+
+---
+
+## Tracking settings
+
+### Enable Tracking
+
+Toggles the entire tracking system on or off without deactivating the plugin. Useful for maintenance windows or GDPR-related pauses.
+
+**Default:** enabled
+
+---
+
+### Track Logged-in Users
+
+When enabled, visitors who are logged in to WordPress will also have their IPs tracked.
+
+**Default:** disabled — only anonymous visitors are tracked
+
+{: .tip }
+Leaving this disabled is the safest default for GDPR compliance, as registered users have a reasonable expectation that their activity is not profiled beyond what they have consented to.
+
+---
+
+### Track Administrators
+
+When enabled, users with the `manage_options` capability (typically site admins) are also tracked. This is a sub-option of **Track Logged-in Users**.
+
+**Default:** disabled
+
+---
+
+### Look Up Private IPs
+
+When enabled, private and reserved IP ranges (e.g. `192.168.x.x`, `10.x.x.x`, `127.0.0.1`) are sent to the IpQuery API. The API will return empty or limited data for these.
+
+**Default:** disabled
+
+{: .note }
+Enable this only when testing on a local development environment (e.g. DDEV, Lando, Docker) where the `REMOTE_ADDR` is always a private IP.
+
+---
+
+### Excluded IPs
+
+A newline-separated list of IP addresses that will never be tracked, regardless of other settings. Useful for excluding your own office IP, staging server crawlers, or known monitoring services.
+
+```
+203.0.113.42
+198.51.100.0
+```
+
+---
+
+### Data Retention
+
+The number of days visitor records are kept. The daily cleanup cron deletes any record whose `last_seen` timestamp is older than this threshold.
+
+**Default:** 90 days  
+**Range:** 1 – 3 650 days
+
+{: .tip }
+For GDPR alignment, consider setting this to 30 days if you have no specific business need for longer retention.
+
+---
+
+## System status
+
+The bottom of the Settings page shows a live status table:
+
+| Check | What it verifies |
+|---|---|
+| PHP ≥ 8.2 | Your server's PHP version |
+| cURL extension | Whether the cURL extension is loaded (required for API calls) |
+| WP Cron (cleanup) | Whether the daily cleanup is scheduled, and when it will next run |
+| DB version | The installed database schema version |
+
+---
+
+## Manual IP lookup
+
+On the **Visitors** screen there is a **Lookup IP…** field. Enter any valid IP address and click **Lookup** to immediately query the IpQuery API and store the result — without waiting for that IP to visit your site.
+
+[View the Visitors screen →]({% link visitors.md %}){: .btn }

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,75 @@
+---
+title: Dashboard
+nav_order: 4
+---
+
+# Dashboard
+
+The dashboard is at **IpQuery → Dashboard**. It gives a live overview of all tracked visitor data.
+
+---
+
+## Stat cards
+
+Four summary cards appear at the top of the page:
+
+| Card | Description |
+|---|---|
+| **Total Visits** | Sum of `visit_count` across all stored IP records |
+| **Unique IPs** | Number of distinct IP addresses in the database |
+| **VPN / Proxy / Tor** | Count of IPs flagged as any of these three risk types |
+| **Risk Rate** | (VPN + Proxy + Tor) ÷ Unique IPs, as a percentage |
+
+---
+
+## Visitor heatmap
+
+An interactive world map rendered with [Leaflet.js](https://leafletjs.com) and the [Leaflet.heat](https://github.com/Leaflet/Leaflet.heat) plugin. Each point represents one stored IP address, weighted by its `visit_count`.
+
+- **Blue** — low intensity
+- **Yellow** — medium intensity
+- **Red** — high intensity (most visits from this location)
+
+The heatmap data is loaded asynchronously via AJAX after the page renders, so it never blocks the initial page load. Up to **500 coordinates** are included, ordered by visit count descending.
+
+{: .note }
+IPs for which the IpQuery API could not determine coordinates (e.g. private IPs, some datacenter ranges) are excluded from the heatmap but still appear in the Visitors table.
+
+---
+
+## Top countries chart
+
+A horizontal bar chart (rendered with [Chart.js](https://www.chartjs.org)) showing the **15 countries with the most visits**. The chart is loaded via the same AJAX call as the heatmap, so it renders without blocking the page.
+
+The same data is also presented as a table on the right side of this row, with flag icons and percentage of total traffic per country.
+
+---
+
+## Risk breakdown
+
+A doughnut chart showing the distribution of risk flags across all unique IPs:
+
+| Segment | Flag |
+|---|---|
+| VPN | `is_vpn = 1` |
+| Proxy | `is_proxy = 1` |
+| Tor | `is_tor = 1` |
+| Datacenter | `is_datacenter = 1` |
+| Mobile | `is_mobile = 1` |
+
+{: .note }
+An IP can have multiple flags. The chart shows counts, not exclusive categories — the same IP may appear in more than one segment.
+
+---
+
+## Risk detail cards
+
+Below the chart row, five individual cards show the absolute count and percentage for each risk type: **VPN**, **Proxy**, **Tor**, **Datacenter**, and **Mobile**.
+
+---
+
+## Data freshness
+
+All stat cards and the country table are server-rendered on page load and reflect the current state of the database at request time. The heatmap and charts load asynchronously and also reflect the current database state.
+
+To see data in the dashboard, at least one visitor IP must have been tracked and successfully looked up via the IpQuery API. You can also use the [manual lookup]({% link visitors.md %}#manual-ip-lookup) on the Visitors screen to seed data immediately.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,58 @@
+---
+title: Home
+nav_order: 1
+permalink: /
+---
+
+# IpQuery for WordPress
+
+Track and analyse visitor IP data directly from your WordPress admin panel — see where your visitors come from on an interactive heatmap, identify VPN and proxy traffic, and drill into per-IP details.
+
+[Get started — Installation]({% link installation.md %}){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[View on GitHub](https://github.com/guibranco/ipquery-wordpress){: .btn .fs-5 .mb-4 .mb-md-0 target="_blank" rel="noopener" }
+
+---
+
+## Features
+
+| Feature | Description |
+|---|---|
+| **World heatmap** | Leaflet.js map with a heat layer showing visitor density by coordinates |
+| **Country breakdown** | Horizontal bar chart of top countries by visit count |
+| **Risk analysis** | Per-IP flags for VPN, proxy, Tor, datacenter, and mobile; risk score 0–100 |
+| **Visitors table** | Sortable, searchable, filterable list of all tracked IPs with full IP details |
+| **Manual IP lookup** | Query any IP address on demand from the Visitors screen |
+| **Automatic tracking** | Hooks into `wp` action; deferred to `shutdown` so page load is never blocked |
+| **Smart caching** | WordPress transients cache each IP lookup for 1 hour — one API call per IP per hour |
+| **Data retention** | Configurable retention period with automatic daily cleanup via WP-Cron |
+| **Privacy controls** | Exclude IPs, skip logged-in users or admins, and disable tracking at any time |
+
+## Powered by ipquery-php
+
+This plugin uses [guibranco/ipquery-php](https://github.com/guibranco/ipquery-php) as its API client library. The library is bundled inside the plugin (no Composer required on your server) and communicates with the [IpQuery API](https://ipquery.io) — a free IP intelligence service providing location, ISP, and risk data.
+
+```
+Visitor request
+      │
+      ▼
+WordPress (wp action)
+      │  deferred to shutdown
+      ▼
+IpQueryClient::getIpData($ip)   ← guibranco/ipquery-php
+      │
+      ▼
+https://api.ipquery.io/{ip}
+      │
+      ▼
+IpQueryResponse { location, isp, risk }
+      │
+      ▼
+wp_ipquery_visitors (DB table)
+```
+
+## Requirements
+
+- WordPress 6.0 or higher
+- PHP 8.2 or higher
+- cURL PHP extension
+- MySQL / MariaDB (standard with any WordPress install)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,70 @@
+---
+title: Installation
+nav_order: 2
+---
+
+# Installation
+
+## Requirements
+
+Before installing, verify your environment meets these requirements:
+
+| Requirement | Minimum |
+|---|---|
+| WordPress | 6.0 |
+| PHP | 8.2 |
+| PHP extension | cURL |
+| Database | MySQL 5.7+ / MariaDB 10.3+ |
+
+{: .note }
+No Composer or external package manager is needed. The [ipquery-php](https://github.com/guibranco/ipquery-php) library is bundled inside the plugin.
+
+---
+
+## Install from GitHub
+
+1. Go to the [Releases page](https://github.com/guibranco/ipquery-wordpress/releases) and download the latest `.zip`.
+2. In your WordPress admin, navigate to **Plugins → Add New Plugin → Upload Plugin**.
+3. Choose the downloaded `.zip` and click **Install Now**.
+4. Click **Activate Plugin**.
+
+## Install manually
+
+1. Clone or download the repository:
+   ```bash
+   git clone https://github.com/guibranco/ipquery-wordpress.git
+   ```
+2. Copy the `ipquery-wordpress` folder into your `wp-content/plugins/` directory.
+3. In your WordPress admin, go to **Plugins** and activate **IpQuery for WordPress**.
+
+---
+
+## What happens on activation
+
+When you activate the plugin, it:
+
+1. Creates the `wp_ipquery_visitors` database table (prefixed with your `$table_prefix`).
+2. Writes default settings to the `ipquery_wp_settings` option.
+3. Schedules a daily WP-Cron event (`ipquery_wp_daily_cleanup`) for automatic data retention.
+
+No changes are made to existing WordPress tables.
+
+---
+
+## What happens on deactivation / uninstall
+
+| Action | Effect |
+|---|---|
+| **Deactivate** | Tracking stops; data and settings are preserved |
+| **Uninstall** (delete from Plugins screen) | Drops the `wp_ipquery_visitors` table and removes all plugin options |
+
+{: .warning }
+Uninstalling the plugin permanently deletes all collected visitor data.
+
+---
+
+## After activation
+
+Once active, the plugin immediately starts tracking visitors (based on your [settings]({% link configuration.md %})). Navigate to **IpQuery → Dashboard** in the WordPress admin sidebar to see the interface.
+
+[Configure the plugin →]({% link configuration.md %}){: .btn .btn-primary }

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,93 @@
+---
+title: Privacy & GDPR
+nav_order: 8
+---
+
+# Privacy & GDPR
+
+This page outlines what data the plugin collects, how long it is kept, and what controls are available to you as the site operator.
+
+{: .important }
+This documentation does not constitute legal advice. You are responsible for assessing whether your use of this plugin complies with applicable privacy laws (GDPR, LGPD, CCPA, etc.) in your jurisdiction.
+
+---
+
+## What is collected
+
+For each unique visitor IP the plugin stores:
+
+| Field | Category | Example |
+|---|---|---|
+| IP address | **Personal data** | `203.0.113.42` |
+| Country, city, state | Derived location | `United States / New York / New York` |
+| Latitude / longitude | Derived location | `40.7128 / -74.0060` |
+| Timezone | Derived location | `America/New_York` |
+| ISP, ASN, organisation | Network metadata | `Spectrum / AS11351` |
+| VPN / Proxy / Tor / DC / Mobile flags | Risk metadata | `false / false / false / false / false` |
+| Risk score | Risk metadata | `12` |
+| First seen, last seen | Timestamps | `2026-03-01 / 2026-04-22` |
+| Visit count | Aggregate counter | `7` |
+
+IP addresses are considered personal data under the GDPR when they can be linked to an individual. All derived fields (location, ISP, risk) are fetched from the third-party [IpQuery API](https://ipquery.io) and stored locally in your WordPress database.
+
+---
+
+## Third-party data transfer
+
+When a visitor's IP is looked up, it is sent to:
+
+```
+https://api.ipquery.io/{ip}?format=json
+```
+
+This is an outbound server-to-server request made from your web server — **not from the visitor's browser**. No cookies, tracking pixels, or browser-side scripts are sent to `ipquery.io`.
+
+You should reference `ipquery.io` in your privacy policy as a sub-processor if you operate under GDPR.
+
+---
+
+## Available controls
+
+| Control | Location | Effect |
+|---|---|---|
+| **Disable tracking** | Settings → Enable Tracking | No IPs are captured or sent to the API |
+| **Exclude logged-in users** | Settings → Track Logged-in Users | Registered users are never tracked |
+| **Exclude admins** | Settings → Track Administrators | `manage_options` users are never tracked |
+| **Exclude specific IPs** | Settings → Excluded IPs | Listed IPs are never tracked or stored |
+| **Data retention** | Settings → Data Retention | Records older than N days are auto-deleted |
+| **Manual delete** | Visitors screen → Delete | Removes a single IP record immediately |
+| **Bulk purge** | Visitors screen → Purge Old Records | Removes all records older than N days immediately |
+
+---
+
+## Data storage
+
+All collected data is stored in the `wp_ipquery_visitors` table in your own WordPress database. No data is sent to any service other than the IpQuery API lookup described above, and the results of that lookup are stored only on your server.
+
+---
+
+## Recommended privacy policy language
+
+If you use this plugin, consider adding a clause similar to the following to your privacy policy:
+
+> We use the IpQuery for WordPress plugin to analyse visitor traffic. Your IP address is sent to the IpQuery API (ipquery.io) to retrieve geolocation and network risk information. This information is stored in our database for up to [X] days and is used solely for security and analytics purposes. It is not shared with third parties. You may request deletion of your data by contacting us at [your contact address].
+
+---
+
+## WordPress Privacy Tools integration
+
+The plugin does not currently register itself with the WordPress core privacy tools (`wp_privacy_send_personal_data_export_requests` / `wp_privacy_personal_data_erasure_fulfilled`). If you need to support data export and erasure requests, you can query and delete records programmatically:
+
+```php
+// Find all records for an IP
+global $wpdb;
+$table = $wpdb->prefix . 'ipquery_visitors';
+$rows  = $wpdb->get_results(
+    $wpdb->prepare( "SELECT * FROM {$table} WHERE ip = %s", $user_ip )
+);
+
+// Delete records for an IP
+IpQuery_DB::delete_ip( $user_ip );
+```
+
+Support for native WordPress privacy tools is planned for a future release.

--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -1,0 +1,131 @@
+---
+title: How Tracking Works
+nav_order: 6
+---
+
+# How Tracking Works
+
+This page explains the technical flow of how visitor IPs are captured, enriched, and stored.
+
+---
+
+## Hook sequence
+
+```
+Browser request
+    │
+    ▼  WordPress bootstrap
+    │
+    ▼  init action
+    │   IpQuery_Tracker::init() — registers the 'wp' hook
+    │
+    ▼  wp action (template resolved)
+    │   IpQuery_Tracker::maybe_track()
+    │    ├─ skip if AJAX / REST / Cron
+    │    ├─ skip if logged-in and settings exclude them
+    │    ├─ resolve client IP (REMOTE_ADDR / proxy headers)
+    │    ├─ skip private IPs (unless setting enabled)
+    │    ├─ skip excluded IPs
+    │    ├─ if transient exists → bump visit count only
+    │    └─ else → register shutdown callback
+    │
+    ▼  Page renders and is sent to browser
+    │
+    ▼  shutdown action
+        IpQuery_Tracker::lookup_and_store()
+         ├─ IpQueryClient::getIpData($ip)  ← ipquery-php library
+         │   └─ GET https://api.ipquery.io/{ip}?format=json
+         ├─ IpQuery_DB::upsert($row)
+         └─ set_transient("ipqwp_{md5($ip)}", 1, HOUR_IN_SECONDS)
+```
+
+The critical design choice is the **`shutdown` deferral**: the API call to IpQuery happens *after* the response has been sent to the visitor's browser. This means tracking never adds latency to page loads.
+
+---
+
+## IP resolution
+
+The tracker resolves the real client IP from the following `$_SERVER` keys, in order:
+
+| Priority | Key | Use case |
+|---|---|---|
+| 1 | `HTTP_CF_CONNECTING_IP` | Cloudflare CDN |
+| 2 | `HTTP_X_REAL_IP` | nginx reverse proxy |
+| 3 | `HTTP_X_FORWARDED_FOR` | standard proxy header (first value) |
+| 4 | `REMOTE_ADDR` | direct connection (fallback) |
+
+Each candidate is validated with `filter_var($ip, FILTER_VALIDATE_IP)` before being used. If no valid IP is found, tracking is silently skipped for that request.
+
+{: .warning }
+`HTTP_X_FORWARDED_FOR` can be spoofed by clients. If your server is not behind a trusted reverse proxy, consider whether Cloudflare or another CDN is in front of your WordPress install. The plugin uses the first IP in the header, which is set by the original client.
+
+---
+
+## Transient caching
+
+Each looked-up IP gets a WordPress transient with the key `ipqwp_{md5($ip)}` and a TTL of **1 hour**. Subsequent visits from the same IP within that hour only trigger a lightweight `UPDATE ... SET visit_count = visit_count + 1` query — no API call is made.
+
+After the hour expires the next visit will trigger a fresh API call, which updates all enrichment fields (location, ISP, risk) in the database row.
+
+---
+
+## Database upsert
+
+`IpQuery_DB::upsert()` checks for an existing row with the same IP:
+
+- **New IP** → `INSERT` with all enrichment fields, `first_seen = NOW()`, `visit_count = 1`
+- **Existing IP (transient expired)** → `UPDATE` all enrichment fields, `last_seen = NOW()`, `visit_count += 1`
+- **Existing IP (transient hit)** → `UPDATE last_seen, visit_count += 1` only (no API call)
+
+---
+
+## What the ipquery-php library provides
+
+The [guibranco/ipquery-php](https://github.com/guibranco/ipquery-php) library handles all communication with the IpQuery API. It is bundled inside `includes/vendor/` and does not require Composer on your server.
+
+The library exposes three methods via `IpQueryClient`:
+
+| Method | Description |
+|---|---|
+| `getMyIpData()` | Returns enrichment data for the server's own outbound IP |
+| `getIpData(string $ip)` | Returns enrichment data for a single IP |
+| `getMultipleIpData(array $ips)` | Batch lookup; returns an array of response objects |
+
+The plugin uses `getIpData()` for all automatic tracking and manual lookups.
+
+Each call returns an `IpQueryResponse` object with three nested objects:
+
+```php
+$response->ip                    // "203.0.113.42"
+
+$response->location->country     // "United States"
+$response->location->countryCode // "US"
+$response->location->city        // "New York"
+$response->location->state       // "New York"
+$response->location->latitude    // 40.7128
+$response->location->longitude   // -74.0060
+$response->location->timezone    // "America/New_York"
+
+$response->isp->asn              // "AS15169"
+$response->isp->org              // "Google LLC"
+$response->isp->isp              // "Google"
+
+$response->risk->isVpn           // false
+$response->risk->isProxy         // false
+$response->risk->isTor           // false
+$response->risk->isDatacenter    // true
+$response->risk->isMobile        // false
+$response->risk->riskScore       // 35
+```
+
+---
+
+## Error handling
+
+All API calls are wrapped in a `try / catch` for `IpQueryException`. If the API is unreachable, returns a non-200 status, or cURL fails, the exception is written to the PHP error log as:
+
+```
+[IpQuery WP] <error message>
+```
+
+The failure is silent to visitors and does not affect page rendering. The transient is not set on failure, so the next visit will try the API again.

--- a/docs/visitors.md
+++ b/docs/visitors.md
@@ -1,0 +1,75 @@
+---
+title: Visitors
+nav_order: 5
+---
+
+# Visitors
+
+The Visitors screen is at **IpQuery → Visitors**. It shows every IP address in the database with its full enrichment data, and provides tools for searching, filtering, manual lookups, and data purging.
+
+---
+
+## Table columns
+
+| Column | Description |
+|---|---|
+| **IP Address** | The raw IP (IPv4 or IPv6) |
+| **Location** | City, state, and country with a country flag |
+| **ISP** | Internet service provider name from the IpQuery API |
+| **Risk Flags** | Colour-coded badges: `VPN`, `Proxy`, `Tor`, `DC` (datacenter), `Mobile`, or `Clean` |
+| **Score** | Numeric risk score 0–100; green ≤ 39, orange 40–79, red ≥ 80 |
+| **Visits** | Total number of page views attributed to this IP |
+| **First Seen** | Date of the first recorded visit |
+| **Last Seen** | Date and time of the most recent visit |
+| **Actions** | Per-row delete button |
+
+Every column header (except ISP and Risk Flags) is sortable — click once to sort ascending, again to sort descending.
+
+---
+
+## Filtering and search
+
+The toolbar above the table provides:
+
+- **Search box** — matches against IP address, city, country, and ISP name simultaneously
+- **Type filter** — restricts results to one risk category: VPN, Proxy, Tor, Datacenter, or Mobile
+- **Reset** button — clears all active filters
+
+Filters are applied server-side and are reflected in the record count shown above the table.
+
+---
+
+## Manual IP lookup
+
+Enter any valid IP address in the **Lookup IP…** field and click **Lookup**. The plugin immediately calls `IpQueryClient::getIpData()` from the [ipquery-php](https://github.com/guibranco/ipquery-php) library and stores the result. The page redirects back with a success or error notice.
+
+This is useful for:
+- Testing the API connection
+- Pre-populating data for known IPs
+- Re-enriching an IP after updating your settings
+
+{: .note }
+Manual lookups bypass the 1-hour transient cache used during normal page tracking. Each manual lookup always makes a fresh API call.
+
+---
+
+## Deleting a single record
+
+Click **Delete** at the end of any row. You will be asked to confirm, after which the record is permanently removed from the database. The transient cache for that IP is **not** cleared, so if that visitor returns within the cache window they will be re-inserted as a new record at the next API call.
+
+---
+
+## Purging old records
+
+At the bottom of the Visitors screen there is a **Purge Old Records** form. Enter a number of days and click **Purge** to immediately delete all records whose `last_seen` date is older than that threshold.
+
+This is a manual complement to the automatic [data retention]({% link configuration.md %}#data-retention) setting, which runs daily via WP-Cron.
+
+{: .warning }
+Purging is irreversible. The deleted records cannot be recovered.
+
+---
+
+## Pagination
+
+Results are paginated at 25 records per page. Pagination links appear below the table when the result set exceeds one page. Sorting and filter parameters are preserved across page navigation.

--- a/ipquery-wordpress.php
+++ b/ipquery-wordpress.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Plugin Name:       IpQuery for WordPress
- * Plugin URI:        https://github.com/guibranco/ipquery-wordpress
- * Description:       Track and analyse visitor IP data using the IpQuery API. Displays location maps, traffic heatmaps, and VPN/proxy statistics.
+ * Plugin URI:        https://guilherme.stracini.com.br/ipquery-wordpress/
+ * Description:       Track and analyse visitor IP data using the IpQuery API (via guibranco/ipquery-php). Displays location maps, traffic heatmaps, and VPN/proxy statistics.
  * Version:           1.0.0
  * Requires at least: 6.0
  * Requires PHP:      8.2


### PR DESCRIPTION
## 📑 Description
[DOCS] Add docs (GitHub Pages)

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add a GitHub Pages-powered documentation site for the IpQuery for WordPress plugin and surface it from the plugin UI.

New Features:
- Introduce a full static documentation site (installation, configuration, dashboard, visitors, tracking, API, privacy) using Jekyll and the just-the-docs theme under the docs/ folder.

Enhancements:
- Update plugin metadata and settings screen to reference the new hosted documentation site and clarify the bundled PHP API client.
- Clarify descriptions of the underlying ipquery-php library and its role within the plugin.

CI:
- Add a GitHub Actions workflow to build the Jekyll docs and publish them to GitHub Pages on changes under docs/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Published comprehensive documentation site with guides for plugin installation, configuration options, API integration, dashboard features, tracking mechanics, privacy and GDPR information, and visitor management.

* **Improvements**
  * Enhanced plugin settings page with quick-access links to full documentation and GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->