### PR TITLE
Update Gemfile

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,10 +1,37 @@
 source "https://rubygems.org"
 
+# ----------------------------------------------------------------------
+#  Core
+# ----------------------------------------------------------------------
 gem "jekyll", "~> 4.3"
-gem "jekyll-remote-theme"
 
+# ----------------------------------------------------------------------
+#  Theme (loaded via `remote_theme:` on GitHub Pages, but we also pin
+#  it locally so `bundle exec jekyll serve` works the same way.)
+# ----------------------------------------------------------------------
+gem "just-the-docs", "0.12.0"
+
+# ----------------------------------------------------------------------
+#  Plugins
+# ----------------------------------------------------------------------
 group :jekyll_plugins do
-  gem "jekyll-remote-theme"
-  gem "jekyll-seo-tag"
-  gem "jekyll-sitemap"
+  gem "jekyll-seo-tag", "~> 2.8"
+  gem "jekyll-sitemap", "~> 1.4"
+  gem "jekyll-github-metadata", "~> 2.16"
+  gem "jekyll-remote-theme", "~> 0.4"
+  gem "jekyll-include-cache", "~> 0.2"
 end
+
+# ----------------------------------------------------------------------
+#  Windows / JRuby helpers (safe no-ops on Linux/macOS)
+# ----------------------------------------------------------------------
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
+
+# Lock webrick for Ruby 3+ (no longer bundled with stdlib)
+gem "webrick", "~> 1.8"


### PR DESCRIPTION
## 📑 Description
Update Gemfile

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Update the documentation site's Gemfile to align with the Just the Docs theme stack and improve local Jekyll compatibility across platforms.

Build:
- Pin theme and plugin gem versions for the docs site and expand the plugin set to include SEO, sitemap, GitHub metadata, and include caching.
- Add platform-specific helper gems and webrick to ensure the docs site runs reliably on Ruby 3+ and Windows/JRuby environments.