### PR TITLE
Fix layout on docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -107,6 +107,16 @@ mermaid:
   version: "10.9.0"
 
 # ----------------------------------------------------------------------
+#  Front-matter defaults — apply Just the Docs layout to every page
+# ----------------------------------------------------------------------
+defaults:
+  - scope:
+      path: ""
+      type: pages
+    values:
+      layout: default
+
+# ----------------------------------------------------------------------
 #  Jekyll build settings
 # ----------------------------------------------------------------------
 markdown: kramdown


### PR DESCRIPTION
## 📑 Description
Fix layout on docs

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Documentation:
- Configure front-matter defaults so all docs pages use the Just the Docs default layout.