### PR TITLE
[CHORE] Use .gitattributes to ignore export files list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Files and directories excluded from git archive / release zips.
+# The leading slash anchors a pattern to the repo root so that e.g.
+# /vendor/ is excluded but includes/vendor/ is kept.
+
+/.github/           export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.wp-env.json       export-ignore
+/_build/            export-ignore
+/docs/              export-ignore
+/tests/             export-ignore
+/vendor/            export-ignore
+/composer.json      export-ignore
+/composer.lock      export-ignore
+/phpunit.xml        export-ignore
+/phpcs.xml          export-ignore
+/GitVersion.yml     export-ignore
+/README.md          export-ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
           VERSION: ${{ needs.version.outputs.fullSemVer }}
         run: |
           mkdir -p /tmp/ipquery
-          git archive HEAD --format=zip --prefix=ipquery/ --output="/tmp/ipquery-${VERSION}.zip"
+          git archive HEAD | tar -x -C /tmp/ipquery
 
       - name: Run WordPress Plugin Check
         uses: wordpress/plugin-check-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Stage plugin under its slug directory
+        env:
+          VERSION: ${{ needs.version.outputs.fullSemVer }}
         run: |
           mkdir -p /tmp/ipquery
-          git archive HEAD | tar -x -C /tmp/ipquery
+          git archive HEAD --format=zip --prefix=ipquery/ --output="/tmp/ipquery-${VERSION}.zip"
 
       - name: Run WordPress Plugin Check
         uses: wordpress/plugin-check-action@v1
@@ -141,7 +143,7 @@ jobs:
         env:
           VERSION: ${{ needs.version.outputs.fullSemVer }}
         run: |
-          git archive HEAD --prefix=ipquery/ --output="/tmp/ipquery-${VERSION}.zip"
+          git archive HEAD --format=zip --prefix=ipquery/ --output="/tmp/ipquery-${VERSION}.zip"
           echo "ZIP=/tmp/ipquery-${VERSION}.zip" >> "$GITHUB_ENV"
 
       - name: Publish GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,21 +80,7 @@ jobs:
       - name: Stage plugin under its slug directory
         run: |
           mkdir -p /tmp/ipquery
-          rsync -a \
-            --exclude='.git'           \
-            --exclude='.github'        \
-            --exclude='.gitignore'     \
-            --exclude='.wp-env.json'   \
-            --exclude='docs'           \
-            --exclude='tests'          \
-            --exclude='/vendor'        \
-            --exclude='composer.json'  \
-            --exclude='composer.lock'  \
-            --exclude='phpunit.xml'    \
-            --exclude='phpcs.xml'      \
-            --exclude='GitVersion.yml' \
-            --exclude='README.md'      \
-            ./ /tmp/ipquery/
+          git archive HEAD | tar -x -C /tmp/ipquery
 
       - name: Run WordPress Plugin Check
         uses: wordpress/plugin-check-action@v1
@@ -155,24 +141,7 @@ jobs:
         env:
           VERSION: ${{ needs.version.outputs.fullSemVer }}
         run: |
-          mkdir -p /tmp/ipquery
-          rsync -a \
-            --exclude='.git'           \
-            --exclude='.github'        \
-            --exclude='.gitignore'     \
-            --exclude='.wp-env.json'   \
-            --exclude='docs'           \
-            --exclude='tests'          \
-            --exclude='/vendor'        \
-            --exclude='composer.json'  \
-            --exclude='composer.lock'  \
-            --exclude='phpunit.xml'    \
-            --exclude='phpcs.xml'      \
-            --exclude='GitVersion.yml' \
-            --exclude='README.md'      \
-            ./ /tmp/ipquery/
-          cd /tmp
-          zip -r "ipquery-${VERSION}.zip" ipquery/
+          git archive HEAD --prefix=ipquery/ --output="/tmp/ipquery-${VERSION}.zip"
           echo "ZIP=/tmp/ipquery-${VERSION}.zip" >> "$GITHUB_ENV"
 
       - name: Publish GitHub Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Stage plugin under its slug directory
         run: |
           mkdir -p /tmp/ipquery
-          git archive HEAD | tar -x -C /tmp/ipquery
+          git archive HEAD --format=zip --prefix=ipquery/ --output="/tmp/ipquery.zip"
 
       - name: Run WordPress Plugin Check
         uses: wordpress/plugin-check-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,21 +72,7 @@ jobs:
       - name: Stage plugin under its slug directory
         run: |
           mkdir -p /tmp/ipquery
-          rsync -a \
-            --exclude='.git'           \
-            --exclude='.github'        \
-            --exclude='.gitignore'     \
-            --exclude='.wp-env.json'   \
-            --exclude='docs'           \
-            --exclude='tests'          \
-            --exclude='/vendor'        \
-            --exclude='composer.json'  \
-            --exclude='composer.lock'  \
-            --exclude='phpunit.xml'    \
-            --exclude='phpcs.xml'      \
-            --exclude='GitVersion.yml' \
-            --exclude='README.md'      \
-            ./ /tmp/ipquery/
+          git archive HEAD | tar -x -C /tmp/ipquery
 
       - name: Run WordPress Plugin Check
         uses: wordpress/plugin-check-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Stage plugin under its slug directory
         run: |
           mkdir -p /tmp/ipquery
-          git archive HEAD --format=zip --prefix=ipquery/ --output="/tmp/ipquery.zip"
+          git archive HEAD | tar -x -C /tmp/ipquery
 
       - name: Run WordPress Plugin Check
         uses: wordpress/plugin-check-action@v1


### PR DESCRIPTION
## 📑 Description
Use .gitattributes to ignore export files list

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Use Git archive-based packaging controlled by .gitattributes for plugin staging and release artifacts.

Build:
- Introduce .gitattributes to define which files are included or excluded from exported plugin packages.

CI:
- Replace rsync-based staging in test workflow with git archive to rely on repository export configuration.
- Update release workflow to build the distributable ZIP directly from git archive instead of manual rsync and zip steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined release and testing workflows by adopting git archive for package generation, improving consistency and ensuring unnecessary files are automatically excluded from distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->