### PR TITLE
[CHORE] Use dark mode in the docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -60,7 +60,7 @@ last_edit_timestamp: true
 last_edit_time_format: "%b %e %Y at %I:%M %p UTC"
 
 # ----------------------------------------------------------------------
-#  Color scheme — light by default, toggle to dark
+#  Color scheme — dark by default, toggle to light
 # ----------------------------------------------------------------------
 color_scheme: dark
 enable_copy_code_button: true

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,8 +13,6 @@ remote_theme: just-the-docs/just-the-docs@v0.12.0
 url: https://guilherme.stracini.com.br
 baseurl: /ipquery-wordpress
 
-color_scheme: dark
-
 # Favicon & logo (drop the files in docs/assets/images/)
 favicon_ico: /assets/images/favicon.ico
 # logo: /assets/images/logo.png
@@ -64,7 +62,7 @@ last_edit_time_format: "%b %e %Y at %I:%M %p UTC"
 # ----------------------------------------------------------------------
 #  Color scheme — light by default, toggle to dark
 # ----------------------------------------------------------------------
-color_scheme: light
+color_scheme: dark
 enable_copy_code_button: true
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## 📑 Description
[CHORE] Use dark mode in the docs

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Enhancements:
- Align documentation theme configuration to consistently use the dark color scheme across the site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default color scheme for the documentation site to dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->