### PR TITLE
feat: add country-based data deletion for GDPR erasure (closes #42) +semver: minor

### DIFF
--- a/admin/views/visitors.php
+++ b/admin/views/visitors.php
@@ -26,12 +26,26 @@ defined( 'ABSPATH' ) || exit; ?>
 	elseif ( isset( $_GET['lookup_error'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		// translators: %s is the error message returned by the lookup.
 		echo '<div class="notice notice-error is-dismissible"><p>' . esc_html( sprintf( __( 'Lookup error: %s', 'ipquery' ), urldecode( sanitize_text_field( wp_unslash( $_GET['lookup_error'] ) ) ) ) ) . '</p></div>'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	elseif ( isset( $_GET['country_deleted'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	elseif ( isset( $_GET['country_deleted'] ) && 'false' !== $_GET['country_deleted'] ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$ipquery_deleted_count   = (int) $_GET['country_deleted']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$ipquery_deleted_country = esc_html( strtoupper( sanitize_text_field( wp_unslash( $_GET['country_code'] ?? '' ) ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		printf(
-			'<div class="notice notice-success is-dismissible"><p>' . esc_html__( '%1$d record(s) deleted for country: %2$s.', 'ipquery' ) . '</p></div>',
-			(int) $_GET['country_deleted'], // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			esc_html( strtoupper( sanitize_text_field( wp_unslash( $_GET['country_code'] ?? '' ) ) ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			'<div class="notice notice-success is-dismissible"><p>' . esc_html(
+				// translators: %1$d is the number of records deleted, %2$s is the country code.
+				sprintf(
+					_n(
+						'%1$d record deleted for country: %2$s.',
+						'%1$d records deleted for country: %2$s.',
+						$ipquery_deleted_count,
+						'ipquery'
+					),
+					$ipquery_deleted_count,
+					$ipquery_deleted_country
+				)
+			) . '</p></div>'
 		);
+	elseif ( isset( $_GET['country_delete_error'] ) || ( isset( $_GET['country_deleted'] ) && 'false' === $_GET['country_deleted'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		echo '<div class="notice notice-error is-dismissible"><p>' . esc_html__( 'Failed to delete records. Please try again.', 'ipquery' ) . '</p></div>';
 	endif;
 	?>
 
@@ -257,7 +271,7 @@ defined( 'ABSPATH' ) || exit; ?>
 	</div>
 
 	<!-- Delete by Country -->
-	<div class="ipquery-panel" style="margin-top:24px;">
+	<div class="ipquery-panel ipquery-panel--spaced">
 		<h3><?php esc_html_e( 'Delete by Country', 'ipquery' ); ?></h3>
 		<p><?php esc_html_e( 'Permanently delete all visitor records from a specific country (GDPR right-to-erasure).', 'ipquery' ); ?></p>
 		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">

--- a/admin/views/visitors.php
+++ b/admin/views/visitors.php
@@ -26,6 +26,12 @@ defined( 'ABSPATH' ) || exit; ?>
 	elseif ( isset( $_GET['lookup_error'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		// translators: %s is the error message returned by the lookup.
 		echo '<div class="notice notice-error is-dismissible"><p>' . esc_html( sprintf( __( 'Lookup error: %s', 'ipquery' ), urldecode( sanitize_text_field( wp_unslash( $_GET['lookup_error'] ) ) ) ) ) . '</p></div>'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	elseif ( isset( $_GET['country_deleted'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		printf(
+			'<div class="notice notice-success is-dismissible"><p>' . esc_html__( '%1$d record(s) deleted for country: %2$s.', 'ipquery' ) . '</p></div>',
+			(int) $_GET['country_deleted'], // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			esc_html( strtoupper( sanitize_text_field( wp_unslash( $_GET['country_code'] ?? '' ) ) ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		);
 	endif;
 	?>
 
@@ -249,5 +255,45 @@ defined( 'ABSPATH' ) || exit; ?>
 			<?php submit_button( __( 'Purge', 'ipquery' ), 'secondary', 'purge_btn', false ); ?>
 		</form>
 	</div>
+
+	<!-- Delete by Country -->
+	<div class="ipquery-panel" style="margin-top:24px;">
+		<h3><?php esc_html_e( 'Delete by Country', 'ipquery' ); ?></h3>
+		<p><?php esc_html_e( 'Permanently delete all visitor records from a specific country (GDPR right-to-erasure).', 'ipquery' ); ?></p>
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<?php wp_nonce_field( 'ipquery_delete_by_country' ); ?>
+			<input type="hidden" name="action" value="ipquery_delete_by_country">
+			<label>
+				<?php esc_html_e( 'Country:', 'ipquery' ); ?>
+				<select name="country_code" required>
+					<option value=""><?php esc_html_e( '— Select a country —', 'ipquery' ); ?></option>
+					<?php
+					// Fetch distinct countries that actually have records.
+					$ipquery_countries = IpQuery_DB::get_distinct_countries();
+					foreach ( $ipquery_countries as $ipquery_country ) :
+						if ( empty( $ipquery_country['country_code'] ) ) {
+							continue;
+						}
+						?>
+					<option value="<?php echo esc_attr( $ipquery_country['country_code'] ); ?>">
+						<?php echo esc_html( $ipquery_country['country'] . ' (' . $ipquery_country['country_code'] . ')' ); ?>
+					</option>
+					<?php endforeach; ?>
+				</select>
+			</label>
+			<?php
+			submit_button(
+				__( 'Delete Records', 'ipquery' ),
+				'secondary',
+				'delete_country_btn',
+				false,
+				array(
+					'onclick' => "return confirm('" . esc_js( __( 'Are you sure? This will permanently delete ALL visitor records from the selected country. This cannot be undone.', 'ipquery' ) ) . "')",
+				)
+			);
+			?>
+		</form>
+	</div>
+
 
 </div>

--- a/admin/views/visitors.php
+++ b/admin/views/visitors.php
@@ -31,8 +31,8 @@ defined( 'ABSPATH' ) || exit; ?>
 		$ipquery_deleted_country = esc_html( strtoupper( sanitize_text_field( wp_unslash( $_GET['country_code'] ?? '' ) ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		printf(
 			'<div class="notice notice-success is-dismissible"><p>' . esc_html(
-				// translators: %1$d is the number of records deleted, %2$s is the country code.
 				sprintf(
+					// translators: %1$d is the number of records deleted, %2$s is the country code.
 					_n(
 						'%1$d record deleted for country: %2$s.',
 						'%1$d records deleted for country: %2$s.',

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -232,3 +232,8 @@
         flex-direction: column;
     }
 }
+
+
+.ipquery-panel--spaced {
+    margin-top: 24px;
+}

--- a/includes/class-ipquery-admin.php
+++ b/includes/class-ipquery-admin.php
@@ -266,7 +266,6 @@ class IpQuery_Admin {
 		);
 		exit;
 	}
-	
 
 	/**
 	 * Handles the bulk-purge form submission.

--- a/includes/class-ipquery-admin.php
+++ b/includes/class-ipquery-admin.php
@@ -25,6 +25,7 @@ class IpQuery_Admin {
 		add_action( 'admin_enqueue_scripts', array( self::class, 'enqueue_assets' ) );
 		add_action( 'admin_init', array( self::class, 'handle_settings_save' ) );
 		add_action( 'admin_post_ipquery_delete_ip', array( self::class, 'handle_delete_ip' ) );
+		add_action( 'admin_post_ipquery_delete_by_country', array( self::class, 'handle_delete_by_country' ) );
 		add_action( 'admin_post_ipquery_purge', array( self::class, 'handle_purge' ) );
 		add_action( 'admin_post_ipquery_lookup', array( self::class, 'handle_manual_lookup' ) );
 		add_action( 'wp_ajax_ipquery_chart_data', array( self::class, 'ajax_chart_data' ) );
@@ -215,6 +216,52 @@ class IpQuery_Admin {
 		wp_safe_redirect( admin_url( 'admin.php?page=ipquery-visitors&deleted=1' ) );
 		exit;
 	}
+
+	/**
+	 * Handles the delete-by-country form submission.
+	 *
+	 * @return void
+	 */
+	public static function handle_delete_by_country(): void {
+		check_admin_referer( 'ipquery_delete_by_country' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Not allowed.', 'ipquery' ) );
+		}
+
+		$country_code = strtoupper(
+			sanitize_text_field( wp_unslash( $_POST['country_code'] ?? '' ) )
+		);
+
+		if ( empty( $country_code ) ) {
+			wp_safe_redirect( admin_url( 'admin.php?page=ipquery-visitors' ) );
+			exit;
+		}
+
+		$deleted = IpQuery_DB::delete_by_country( $country_code );
+
+		if ( $deleted !== false ) {
+			
+			IpQuery_DB::log_action(
+				sprintf(
+					'Admin "%s" deleted %d visitor record(s) for country: %s',
+					wp_get_current_user()->user_login,
+					(int) $deleted,
+					$country_code
+				)
+			);
+		}
+
+		wp_safe_redirect(
+			admin_url(
+				'admin.php?page=ipquery-visitors'
+				. '&country_deleted=' . (int) $deleted
+				. '&country_code=' . rawurlencode( $country_code )
+			)
+		);
+		exit;
+	}
+
+	
 
 	/**
 	 * Handles the bulk-purge form submission.

--- a/includes/class-ipquery-admin.php
+++ b/includes/class-ipquery-admin.php
@@ -239,28 +239,33 @@ class IpQuery_Admin {
 
 		$deleted = IpQuery_DB::delete_by_country( $country_code );
 
-		if ( $deleted !== false ) {
-			
-			IpQuery_DB::log_action(
-				sprintf(
-					'Admin "%s" deleted %d visitor record(s) for country: %s',
-					wp_get_current_user()->user_login,
-					(int) $deleted,
-					$country_code
-				)
+		if ( false === $deleted ) {
+			wp_safe_redirect(
+				admin_url( 'admin.php?page=ipquery-visitors&country_delete_error=1' )
 			);
+			exit;
 		}
+
+		IpQuery_DB::log_action(
+			sprintf(
+				'Admin "%s" deleted %d visitor record(s) for country: %s',
+				wp_get_current_user()->user_login,
+				(int) $deleted,
+				$country_code
+			)
+		);
+
+		$deleted_param = (string) (int) $deleted;
 
 		wp_safe_redirect(
 			admin_url(
 				'admin.php?page=ipquery-visitors'
-				. '&country_deleted=' . (int) $deleted
+				. '&country_deleted=' . $deleted_param
 				. '&country_code=' . rawurlencode( $country_code )
 			)
 		);
 		exit;
 	}
-
 	
 
 	/**

--- a/includes/class-ipquery-db.php
+++ b/includes/class-ipquery-db.php
@@ -305,4 +305,49 @@ class IpQuery_DB {
 		$table = $wpdb->prefix . IPQUERY_TABLE;
 		$wpdb->delete( $table, array( 'ip' => $ip ), array( '%s' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 	}
+	
+	/**
+	 * Writes an audit message to the WordPress debug log when WP_DEBUG_LOG is enabled.
+	 *
+	 * @param string $message The message to log.
+	 * @return void
+	 */
+	public static function log_action( string $message ): void {
+		if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( '[IpQuery] ' . $message );
+		}
+	}
+
+	/**
+	 * Delete all visitor records for a given country code.
+	 *
+	 * @param string $country_code Two-letter ISO country code (e.g. 'DE').
+	 * @return int|false Number of rows deleted, or false on error.
+	 */
+	public static function delete_by_country( string $country_code ) : int|false {
+		global $wpdb;
+		$table = $wpdb->prefix . IPQUERY_TABLE;
+		return $wpdb->delete( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$table,
+			array( 'country_code' => sanitize_text_field( $country_code ) ),
+			array( '%s' )
+		);
+	}
+
+	/**
+	 * Returns distinct countries that have visitor records, for the deletion dropdown.
+	 *
+	 * @return array<int,array{country:string,country_code:string}>
+	 */
+	public static function get_distinct_countries(): array {
+		global $wpdb;
+		$table  = $wpdb->prefix . IPQUERY_TABLE;
+		$result = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT DISTINCT country, country_code FROM {$table} WHERE country_code IS NOT NULL AND country_code != '' ORDER BY country ASC",
+			ARRAY_A
+		);
+		return is_array( $result ) ? $result : array();
+	}	
+
 }

--- a/includes/class-ipquery-db.php
+++ b/includes/class-ipquery-db.php
@@ -305,7 +305,7 @@ class IpQuery_DB {
 		$table = $wpdb->prefix . IPQUERY_TABLE;
 		$wpdb->delete( $table, array( 'ip' => $ip ), array( '%s' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 	}
-	
+
 	/**
 	 * Writes an audit message to the WordPress debug log when WP_DEBUG_LOG is enabled.
 	 *
@@ -325,7 +325,7 @@ class IpQuery_DB {
 	 * @param string $country_code Two-letter ISO country code (e.g. 'DE').
 	 * @return int|false Number of rows deleted, or false on error.
 	 */
-	public static function delete_by_country( string $country_code ) : int|false {
+	public static function delete_by_country( string $country_code ): int|false {
 		global $wpdb;
 		$table = $wpdb->prefix . IPQUERY_TABLE;
 		return $wpdb->delete( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -343,11 +343,7 @@ class IpQuery_DB {
 	public static function get_distinct_countries(): array {
 		global $wpdb;
 		$table  = $wpdb->prefix . IPQUERY_TABLE;
-		$result = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			"SELECT DISTINCT country, country_code FROM {$table} WHERE country_code IS NOT NULL AND country_code != '' ORDER BY country ASC",
-			ARRAY_A
-		);
+		$result = $wpdb->get_results( "SELECT DISTINCT country, country_code FROM {$table} WHERE country_code IS NOT NULL AND country_code != '' ORDER BY country ASC", ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		return is_array( $result ) ? $result : array();
-	}	
-
+	}
 }


### PR DESCRIPTION
Closes #42

## 📑 Description

Adds country-based visitor data deletion to support GDPR right-to-erasure workflows.

Changes made across 3 files:

- `includes/class-ipquery-db.php`
  - [x] Added `delete_by_country(string $country_code): int|false` — deletes all visitor rows matching a given ISO country code
  - [x] Added `get_distinct_countries(): array` — returns distinct countries that have records, used to populate the dropdown
  - [x] Added `log_action(string $message): void` — writes audit entries to the WordPress debug log when `WP_DEBUG_LOG` is enabled

- `includes/class-ipquery-admin.php`
  - [x] Registered `admin_post_ipquery_delete_by_country` hook in `init()`
  - [x] Added `handle_delete_by_country()` — validates nonce, checks capability, calls `IpQuery_DB::delete_by_country()`, logs the action, and redirects with a success notice

- `admin/views/visitors.php`
  - [x] Added success notice for `country_deleted` redirect param
  - [x] Added "Delete by Country" panel at the bottom with a dropdown populated from actual DB records, nonce protection, `required` attribute, and an `onclick` confirmation dialog

## Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

##  Does this introduce a breaking change?
- [ ] Yes
- [x] No

##  Additional Information

- The dropdown only shows countries that **actually have records** in the database — no point showing countries with nothing to delete
- Deletion is logged via `IpQuery_DB::log_action()` which only writes when `WP_DEBUG_LOG` is `true`, consistent with WordPress best practices. Note: existing handlers (`handle_delete_ip`, `handle_purge`) do not currently log — this PR introduces logging specifically to satisfy the acceptance criteria of issue #42
- A `$deleted !== false` check distinguishes a real DB failure from a legitimate "0 rows deleted" result
- No breaking changes — all existing functionality is untouched

## Summary by Sourcery

Add support for deleting visitor records by country to help fulfill GDPR right-to-erasure requests.

New Features:
- Introduce a delete-by-country admin action and handler for removing all visitor records for a selected country.
- Add a visitor admin UI panel with a country dropdown and confirmation flow to trigger country-based deletion.
- Expose database methods to delete visitor records by country and to retrieve distinct countries with stored records.

Enhancements:
- Log admin-initiated deletion actions to the WordPress debug log when enabled.
- Display a success notice summarizing the outcome of country-based deletions in the visitors admin screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Delete by Country" bulk-deletion tool in the admin Visitors panel with a country selector and confirmation prompt for irreversible deletions.
  * Shows a summary after deletion including the uppercased country code and number of records removed.

* **Style**
  * Minor spacing adjustments to admin panel layout for improved spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->