### PR TITLE
docs: add Delete by Country section to visitors docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ Track and analyse visitor IP data directly from your WordPress admin panel — s
 | **Smart caching** | WordPress transients cache each IP lookup for 1 hour — one API call per IP per hour |
 | **Data retention** | Configurable retention period with automatic daily cleanup via WP-Cron |
 | **Privacy controls** | Exclude IPs, skip logged-in users or admins, and disable tracking at any time |
+| **GDPR erasure by country** | Bulk-delete all visitor records for one or more countries; confirmation dialog and audit log included |
 
 ## Powered by ipquery-php
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -75,6 +75,21 @@ If you use this plugin, consider adding a clause similar to the following to you
 
 ---
 
+## GDPR right-to-erasure by country
+
+The **Delete by Country** tool on the Visitors screen is designed specifically for right-to-erasure (Article 17 GDPR) workflows where a data protection authority or your own DPA policy requires you to remove all data relating to residents of a particular country or jurisdiction.
+
+Key properties of the tool:
+
+- **Targeted** — selects records by the `country_code` field stored from the IpQuery API response; only countries with stored records are shown.
+- **Bulk** — a single operation removes all matching records across as many countries as you select.
+- **Safe** — a mandatory confirmation dialog shows the affected countries and record count before any data is deleted.
+- **Auditable** — every deletion is written to the plugin action log (`IpQuery → Logs`) with the operator identity, country list, record count, and UTC timestamp.
+
+See [Deleting records by country]({% link visitors.md %}#deleting-records-by-country) for step-by-step instructions.
+
+---
+
 ## WordPress Privacy Tools integration
 
 The plugin does not currently register itself with the WordPress core privacy tools (`wp_privacy_send_personal_data_export_requests` / `wp_privacy_personal_data_erasure_fulfilled`). If you need to support data export and erasure requests, you can query and delete records programmatically:
@@ -89,6 +104,12 @@ $rows  = $wpdb->get_results(
 
 // Delete records for an IP
 IpQuery_DB::delete_ip( $user_ip );
+
+// Delete all records for a country (ISO alpha-2 code)
+IpQuery_DB::delete_by_country( 'DE' );
+
+// Delete records for multiple countries at once
+IpQuery_DB::delete_by_countries( [ 'DE', 'FR', 'IT' ] );
 ```
 
-Support for native WordPress privacy tools is planned for a future release.
+Support for native WordPress privacy tools (data export and per-user erasure requests via the admin UI) is planned for a future release.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -57,6 +57,7 @@ You should reference `ipquery.io` in your privacy policy as a sub-processor if y
 | **Data retention** | Settings → Data Retention | Records older than N days are auto-deleted |
 | **Manual delete** | Visitors screen → Delete | Removes a single IP record immediately |
 | **Bulk purge** | Visitors screen → Purge Old Records | Removes all records older than N days immediately |
+| **Delete by country** | Visitors screen → Delete by Country | Bulk-removes all records from one or more selected countries; requires confirmation; action is logged |
 
 ---
 

--- a/docs/visitors.md
+++ b/docs/visitors.md
@@ -70,6 +70,43 @@ Purging is irreversible. The deleted records cannot be recovered.
 
 ---
 
+## Deleting records by country
+
+The **Delete by Country** tool supports GDPR right-to-erasure workflows by removing all stored visitor records that originate from one or more specific countries.
+
+### How to use it
+
+1. In the **Delete by Country** section at the bottom of the Visitors screen, select one or more countries from the dropdown. Countries are listed by name alongside their ISO 3166-1 alpha-2 code and the current number of records stored for each.
+2. Click **Delete Selected Countries**.
+3. A confirmation dialog appears showing the number of records that will be deleted and the countries affected. Confirm to proceed or cancel to abort.
+4. On confirmation, all matching records are permanently deleted and a success notice is displayed with the total count removed.
+
+### Bulk deletion
+
+You can select multiple countries in a single operation. All records matching any of the selected countries are deleted in one database transaction.
+
+### Audit log
+
+Every country-filter deletion is written to the plugin's action log with:
+
+| Field | Value |
+|---|---|
+| **Action** | `delete_by_country` |
+| **Countries** | Comma-separated list of ISO country codes deleted |
+| **Records deleted** | Total row count removed |
+| **Performed by** | WordPress user ID and display name |
+| **Timestamp** | UTC date and time of the operation |
+
+The log is accessible under **IpQuery → Logs** and is retained for 90 days.
+
+{: .warning }
+Country-filter deletion is irreversible. All records for the selected countries are permanently removed and cannot be recovered.
+
+{: .note }
+The country dropdown only lists countries for which at least one record is currently stored. If a country does not appear, no records exist for it.
+
+---
+
 ## Pagination
 
 Results are paginated at 25 records per page. Pagination links appear below the table when the result set exceeds one page. Sorting and filter parameters are preserved across page navigation.


### PR DESCRIPTION
## 📑 Description
Document the Delete by Country feature, including step-by-step usage, bulk deletion support, and audit log fields. Add a corresponding row to the privacy controls table in privacy.md.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Document the new Delete by Country functionality for visitor records and align privacy documentation accordingly.

Documentation:
- Add a Visitors guide section describing Delete by Country usage, bulk deletion behavior, and related audit logging details.
- Clarify irreversibility and scope of country-based deletions and how countries appear in the deletion dropdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “Delete by country” / GDPR right-to-erasure docs: bulk country-based deletion with confirmation dialog showing affected counts.
  * Described irreversible workflow, country selector behavior (only countries with records), single-transaction bulk deletion, and 90-day audit log retention.
  * Updated privacy guidance and examples for using the new erasure option.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/guibranco/ipquery-wordpress/pull/55)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->