### PR TITLE
refactor: update hook check in asset enqueuing

### DIFF
--- a/includes/class-sva-admin.php
+++ b/includes/class-sva-admin.php
@@ -87,7 +87,7 @@ class SVA_Admin {
 	 * @return void
 	 */
 	public static function enqueue_assets( string $hook ): void {
-		if ( ! str_contains( $hook, 'stracini-visitor-analytics' ) ) {
+		if ( ! str_contains( $hook, 'sva-' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
## 📑 Description
Change the string check in the `enqueue_assets` function from 'stracini-visitor-analytics' to 'sva-'. This update helps broaden the scope and future-proofs the function for additional sub-pages or features that may have 'sva-' namespaces. Additionally, this ensures that asset enqueuing applies consistently across new admin pages related to the plugin.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Broaden the admin asset enqueuing hook check to match all plugin-related pages using the generic 'sva-' namespace instead of a specific slug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the admin interface asset loading mechanism to ensure plugin CSS and JavaScript resources are correctly delivered to the intended administrative pages, preventing unnecessary resource loading on unrelated pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->